### PR TITLE
update phpunit config

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     bootstrap="vendor/autoload.php"
     backupGlobals="false"
     backupStaticAttributes="false"
@@ -10,22 +10,24 @@
     convertWarningsToExceptions="true"
     processIsolation="false"
     stopOnFailure="false"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
 >
+    <coverage>
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+        <report>
+            <clover outputFile="build/logs/clover.xml"/>
+            <html outputDirectory="build/coverage"/>
+            <text outputFile="build/coverage.txt"/>
+        </report>
+    </coverage>
     <testsuites>
         <testsuite name="mazedlx.net Test Suite">
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
     <logging>
-        <log type="tap" target="build/report.tap" />
-        <log type="junit" target="build/report.junit.xml" />
-        <log type="coverage-html" target="build/coverage" />
-        <log type="coverage-text" target="build/coverage.txt" />
-        <log type="coverage-clover" target="build/logs/clover.xml" />
+        <junit outputFile="build/report.junit.xml"/>
     </logging>
 </phpunit>


### PR DESCRIPTION
I'm looking into adding support for Laravel 10, noticed that the phpunit was out of date.
This PR updates it, using the command provided by phpunit itsself.
```shell
./vendor/bin/phpunit --migrate-configuration
```

I've done the same for a few other packages
- https://github.com/fico7489/laravel-pivot/pull/89
- https://github.com/staudenmeir/laravel-cte/pull/44