### PR TITLE
[Laravel 10] update composer constraints 

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -14,9 +14,9 @@ jobs:
         os:
           - ubuntu-latest
         php:
-          - 7.4
           - 8.0
           - 8.1
+          - 8.2
 
     steps:
       - name: Checkout code

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -31,7 +31,7 @@ jobs:
           coverage: none
 
       - name: Install Composer dependencies
-        run: composer install --prefer-dist --no-interaction --no-suggest
+        run: composer install --prefer-dist --no-interaction
 
       - name: Run analysis
         run: phpstan analyse --no-ansi --no-interaction --no-progress

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
           coverage: none
 
       - name: Install Composer dependencies
-        run: composer install --prefer-dist --no-interaction --no-suggest
+        run: composer install --prefer-dist --no-interaction
 
       - name: Execute tests
         run: vendor/bin/phpunit --verbose

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,9 +14,9 @@ jobs:
         os:
           - ubuntu-latest
         php:
-          - 7.4
           - 8.0
           - 8.1
+          - 8.2
 
     steps:
       - name: Checkout code

--- a/composer.json
+++ b/composer.json
@@ -18,12 +18,12 @@
   ],
   "minimum-stability": "stable",
   "require": {
-    "php": "^7.4|^8.0|^8.1",
-    "illuminate/http": "~5.5.0|~5.6.0|~5.7.0|~5.8.0|^6.0|^7.0|^8.0|^9.0",
-    "illuminate/support": "~5.5.0|~5.6.0|~5.7.0|~5.8.0|^6.0|^7.0|^8.0|^9.0"
+    "php": "^7.4|^8.0|^8.1|^8.2",
+    "illuminate/http": "^7.0|^8.0|^9.0|^10.0",
+    "illuminate/support": "^7.0|^8.0|^9.0|^10.0"
   },
   "require-dev": {
-    "orchestra/testbench": "~3.5|~3.6|~3.7|~3.8|^4.0|^5.0|^6.0|^7.0",
+    "orchestra/testbench": "^7.0|^8.0|^9.0",
     "phpunit/phpunit": "^8.0|^9.0"
   },
   "autoload": {


### PR DESCRIPTION
This PR adds Laravel 10 support by;

1. update the constraints for the Illuminate packages that are being used
2. adds PHP 8.2 as supported PHP version
3. updates the CI to also support this version
4. drops support for PHP 7.4

@mazedlx maybe we should also drop PHP 8.0 support, as Laravel 10 [requires](https://laravel.com/docs/10.x/upgrade#updating-dependencies) PHP 8.1