### PR TITLE
add templates for Github issues and pull requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,64 @@
+name: Bug Report
+description: File a bug report
+title: "[Bug]: "
+labels: ["bug", "triage"]
+assignees:
+  - mazedlx
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+
+  - type: input
+    id: contact
+    attributes:
+      label: Contact Details
+      description: How can we get in touch with you if we need more info?
+      placeholder: ex. email@example.com
+    validations:
+      required: false
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Also tell us, what did you expect to happen?
+      placeholder: Tell us what you see!
+      value: "A bug happened!"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: version
+    attributes:
+      label: Version
+      description: What version of our software are you running?
+      options:
+        - 1.0.0
+        - 1.0.1
+        - 1.0.7
+        - 1.0.8
+        - 1.0.9
+        - 1.1.2
+        - 1.2.0
+        - 1.3.0
+        - 2.0.0
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      render: shell
+
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://example.com)
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,43 @@
+name: Change request
+description: Request a new feature, propose a change or if you just have a question.
+title: "[Feature]: "
+labels: ["enhancement"]
+assignees:
+  -
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improving this package.
+
+        Let us know if there is something that can be improved; an awesome new feature that should be added or if you just have a question.
+
+  - type: dropdown
+    id: request-type
+    attributes:
+      label: Type of request
+      description: What kind of request is this?
+      options:
+        - improvement
+        - new feature
+        - question
+    validations:
+      required: true
+
+  - type: textarea
+    id: request
+    attributes:
+      label: Requested change or question
+      description: What is your proposed change or improvement.
+      placeholder: What's you idea or request, or if you just have a question.
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://example.com)
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+## What does this pull request change or introduce
+
+## What is the impact of these changes
+
+## Checklist
+- [ ] An issue was created before proposing this change
+- [ ] Tests for the changes have been added
+- [ ] Tests are passing
+
+## Steps to reproduce / test
+1.
+
+## Other information:


### PR DESCRIPTION
This pull request resolves #19

## What does this pull request change or introduce
It introduces issue forms for bugs and change requests and a pull request template.

## What is the impact of these changes
Creating issues / pull requests on Github

## Checklist
- [x] An issue was created before proposing this change
- [ ] Tests for the changes have been added
- [ ] Tests are passing

## Steps to reproduce / test
These kind of changes are hard to test, same goes for Github Actions. The main reason for this is that these changes only become visible when they are present on the main branch.

I have, because of this, pushed these changes to the main branch of my fork.

To see an example of the pull request template; use [this link](https://github.com/Treggats/laravel-feature-policy/compare/main...Treggats:laravel-feature-policy:refactor/directives?expand=1) to open the new pull request page. The template should be auto filled.

To see the issue forms in action, go to the issue tab and click on "new issue". The two added issue forms should be available to create.

## Other information
@mazedlx I can image that certain wording or sentences are not completely to you liking. Feel free to edit.