### PR TITLE
[bugfix] could only create rules for one feature group

### DIFF
--- a/src/Directive.php
+++ b/src/Directive.php
@@ -7,7 +7,7 @@ use Mazedlx\FeaturePolicy\FeatureGroups\DirectiveContract;
 use Mazedlx\FeaturePolicy\FeatureGroups\ProposedFeatureGroup;
 use Mazedlx\FeaturePolicy\Exceptions\UnknownPermissionGroupException;
 
-abstract class Directive
+abstract class Directive implements DirectiveContract
 {
     protected array $rules = [];
 

--- a/src/FeatureGroups/DefaultFeatureGroup.php
+++ b/src/FeatureGroups/DefaultFeatureGroup.php
@@ -12,7 +12,7 @@ final class DefaultFeatureGroup implements FeatureGroupContract
     public static function directive(string $directive): DirectiveContract
     {
         return match ($directive) {
-            Directive::ACCELEROMETER => new class extends Directive implements DirectiveContract {
+            Directive::ACCELEROMETER => new class extends Directive {
                 public function name(): string
                 {
                     return Directive::ACCELEROMETER;
@@ -38,7 +38,7 @@ final class DefaultFeatureGroup implements FeatureGroupContract
                     return 'https://www.chromestatus.com/feature/5758486868656128';
                 }
             },
-            Directive::AMBIENT_LIGHT_SENSOR => new class extends Directive implements DirectiveContract {
+            Directive::AMBIENT_LIGHT_SENSOR => new class extends Directive {
                 public function name(): string
                 {
                     return Directive::AMBIENT_LIGHT_SENSOR;
@@ -64,7 +64,7 @@ final class DefaultFeatureGroup implements FeatureGroupContract
                     return 'https://www.chromestatus.com/feature/5758486868656128';
                 }
             },
-            Directive::AUTOPLAY => new class extends Directive implements DirectiveContract {
+            Directive::AUTOPLAY => new class extends Directive {
                 public function name(): string
                 {
                     return Directive::AUTOPLAY;
@@ -90,7 +90,7 @@ final class DefaultFeatureGroup implements FeatureGroupContract
                     return 'https://www.chromestatus.com/feature/5100524789563392';
                 }
             },
-            Directive::BATTERY => new class extends Directive implements DirectiveContract {
+            Directive::BATTERY => new class extends Directive {
                 public function name(): string
                 {
                     return Directive::BATTERY;
@@ -116,7 +116,7 @@ final class DefaultFeatureGroup implements FeatureGroupContract
                     return 'https://bugs.chromium.org/p/chromium/issues/detail?id=1007264';
                 }
             },
-            Directive::BLUETOOTH => new class extends Directive implements DirectiveContract {
+            Directive::BLUETOOTH => new class extends Directive {
                 public function name(): string
                 {
                     return Directive::BLUETOOTH;
@@ -142,7 +142,7 @@ final class DefaultFeatureGroup implements FeatureGroupContract
                     return 'https://chromestatus.com/feature/6439287120723968';
                 }
             },
-            Directive::CAMERA => new class extends Directive implements DirectiveContract {
+            Directive::CAMERA => new class extends Directive {
                 public function name(): string
                 {
                     return Directive::CAMERA;
@@ -168,7 +168,7 @@ final class DefaultFeatureGroup implements FeatureGroupContract
                     return 'https://www.chromestatus.com/feature/5023919287304192';
                 }
             },
-            Directive::CH_UA => new class extends Directive implements DirectiveContract {
+            Directive::CH_UA => new class extends Directive {
                 public function name(): string
                 {
                     return Directive::CH_UA;
@@ -194,7 +194,7 @@ final class DefaultFeatureGroup implements FeatureGroupContract
                     return 'https://chromestatus.com/feature/5995832180473856';
                 }
             },
-            Directive::CH_UA_ARCH => new class extends Directive implements DirectiveContract {
+            Directive::CH_UA_ARCH => new class extends Directive {
                 public function name(): string
                 {
                     return Directive::CH_UA_ARCH;
@@ -220,7 +220,7 @@ final class DefaultFeatureGroup implements FeatureGroupContract
                     return 'https://chromestatus.com/feature/5995832180473856';
                 }
             },
-            Directive::CH_UA_BITNESS => new class extends Directive implements DirectiveContract {
+            Directive::CH_UA_BITNESS => new class extends Directive {
                 public function name(): string
                 {
                     return Directive::CH_UA_BITNESS;
@@ -246,7 +246,7 @@ final class DefaultFeatureGroup implements FeatureGroupContract
                     return 'https://chromestatus.com/feature/5995832180473856';
                 }
             },
-            Directive::CH_UA_FULL_VERSION => new class extends Directive implements DirectiveContract {
+            Directive::CH_UA_FULL_VERSION => new class extends Directive {
                 public function name(): string
                 {
                     return Directive::CH_UA_FULL_VERSION;
@@ -272,7 +272,7 @@ final class DefaultFeatureGroup implements FeatureGroupContract
                     return 'https://chromestatus.com/feature/5995832180473856';
                 }
             },
-            Directive::CH_UA_FULL_VERSION_LIST => new class extends Directive implements DirectiveContract {
+            Directive::CH_UA_FULL_VERSION_LIST => new class extends Directive {
                 public function name(): string
                 {
                     return Directive::CH_UA_FULL_VERSION_LIST;
@@ -298,7 +298,7 @@ final class DefaultFeatureGroup implements FeatureGroupContract
                     return 'https://chromestatus.com/feature/5995832180473856';
                 }
             },
-            Directive::CH_UA_MOBILE => new class extends Directive implements DirectiveContract {
+            Directive::CH_UA_MOBILE => new class extends Directive {
                 public function name(): string
                 {
                     return Directive::CH_UA_MOBILE;
@@ -324,7 +324,7 @@ final class DefaultFeatureGroup implements FeatureGroupContract
                     return 'https://chromestatus.com/feature/5995832180473856';
                 }
             },
-            Directive::CH_UA_MODEL => new class extends Directive implements DirectiveContract {
+            Directive::CH_UA_MODEL => new class extends Directive {
                 public function name(): string
                 {
                     return Directive::CH_UA_MODEL;
@@ -350,7 +350,7 @@ final class DefaultFeatureGroup implements FeatureGroupContract
                     return 'https://chromestatus.com/feature/5995832180473856';
                 }
             },
-            Directive::CH_UA_PLATFORM => new class extends Directive implements DirectiveContract {
+            Directive::CH_UA_PLATFORM => new class extends Directive {
                 public function name(): string
                 {
                     return Directive::CH_UA_PLATFORM;
@@ -376,7 +376,7 @@ final class DefaultFeatureGroup implements FeatureGroupContract
                     return 'https://chromestatus.com/feature/5995832180473856';
                 }
             },
-            Directive::CH_UA_PLATFORM_VERSION => new class extends Directive implements DirectiveContract {
+            Directive::CH_UA_PLATFORM_VERSION => new class extends Directive {
                 public function name(): string
                 {
                     return Directive::CH_UA_PLATFORM_VERSION;
@@ -402,7 +402,7 @@ final class DefaultFeatureGroup implements FeatureGroupContract
                     return 'https://chromestatus.com/feature/5995832180473856';
                 }
             },
-            Directive::CH_UA_WOW64 => new class extends Directive implements DirectiveContract {
+            Directive::CH_UA_WOW64 => new class extends Directive {
                 public function name(): string
                 {
                     return Directive::CH_UA_WOW64;
@@ -428,7 +428,7 @@ final class DefaultFeatureGroup implements FeatureGroupContract
                     return 'https://chromestatus.com/feature/5995832180473856';
                 }
             },
-            Directive::CROSS_ORIGIN_ISOLATED => new class extends Directive implements DirectiveContract {
+            Directive::CROSS_ORIGIN_ISOLATED => new class extends Directive {
                 public function name(): string
                 {
                     return Directive::CROSS_ORIGIN_ISOLATED;
@@ -454,7 +454,7 @@ final class DefaultFeatureGroup implements FeatureGroupContract
                     return '';
                 }
             },
-            Directive::DISPLAY_CAPTURE => new class extends Directive implements DirectiveContract {
+            Directive::DISPLAY_CAPTURE => new class extends Directive {
                 public function name(): string
                 {
                     return Directive::DISPLAY_CAPTURE;
@@ -480,7 +480,7 @@ final class DefaultFeatureGroup implements FeatureGroupContract
                     return 'https://chromestatus.com/feature/5144822362931200';
                 }
             },
-            Directive::DOCUMENT_DOMAIN => new class extends Directive implements DirectiveContract {
+            Directive::DOCUMENT_DOMAIN => new class extends Directive {
                 public function name(): string
                 {
                     return Directive::DOCUMENT_DOMAIN;
@@ -516,7 +516,7 @@ final class DefaultFeatureGroup implements FeatureGroupContract
                     return true;
                 }
             },
-            Directive::ENCRYPTED_MEDIA => new class extends Directive implements DirectiveContract {
+            Directive::ENCRYPTED_MEDIA => new class extends Directive {
                 public function name(): string
                 {
                     return Directive::ENCRYPTED_MEDIA;
@@ -542,7 +542,7 @@ final class DefaultFeatureGroup implements FeatureGroupContract
                     return 'https://www.chromestatus.com/feature/5023919287304192';
                 }
             },
-            Directive::EXECUTION_WHILE_NOT_RENDERED => new class extends Directive implements DirectiveContract {
+            Directive::EXECUTION_WHILE_NOT_RENDERED => new class extends Directive {
                 public function name(): string
                 {
                     return Directive::EXECUTION_WHILE_NOT_RENDERED;
@@ -573,7 +573,7 @@ final class DefaultFeatureGroup implements FeatureGroupContract
                     return 'To enable these, use the Chrome command line flag --enable-blink-features=ExperimentalProductivityFeatures.';
                 }
             },
-            Directive::EXECUTION_WHILE_OUT_OF_VIEWPORT => new class extends Directive implements DirectiveContract {
+            Directive::EXECUTION_WHILE_OUT_OF_VIEWPORT => new class extends Directive {
                 public function name(): string
                 {
                     return Directive::EXECUTION_WHILE_OUT_OF_VIEWPORT;
@@ -604,7 +604,7 @@ final class DefaultFeatureGroup implements FeatureGroupContract
                     return 'To enable these, use the Chrome command line flag --enable-blink-features=ExperimentalProductivityFeatures.';
                 }
             },
-            Directive::FULLSCREEN => new class extends Directive implements DirectiveContract {
+            Directive::FULLSCREEN => new class extends Directive {
                 public function name(): string
                 {
                     return Directive::FULLSCREEN;
@@ -630,7 +630,7 @@ final class DefaultFeatureGroup implements FeatureGroupContract
                     return 'https://www.chromestatus.com/feature/5094837900541952';
                 }
             },
-            Directive::GEOLOCATION => new class extends Directive implements DirectiveContract {
+            Directive::GEOLOCATION => new class extends Directive {
                 public function name(): string
                 {
                     return Directive::GEOLOCATION;
@@ -656,7 +656,7 @@ final class DefaultFeatureGroup implements FeatureGroupContract
                     return 'https://www.chromestatus.com/feature/5023919287304192';
                 }
             },
-            Directive::GYROSCOPE => new class extends Directive implements DirectiveContract {
+            Directive::GYROSCOPE => new class extends Directive {
                 public function name(): string
                 {
                     return Directive::GYROSCOPE;
@@ -682,7 +682,7 @@ final class DefaultFeatureGroup implements FeatureGroupContract
                     return 'https://www.chromestatus.com/feature/5758486868656128';
                 }
             },
-            Directive::HID => new class extends Directive implements DirectiveContract {
+            Directive::HID => new class extends Directive {
                 public function name(): string
                 {
                     return Directive::HID;
@@ -708,7 +708,7 @@ final class DefaultFeatureGroup implements FeatureGroupContract
                     return '';
                 }
             },
-            Directive::IDLE_DETECTION => new class extends Directive implements DirectiveContract {
+            Directive::IDLE_DETECTION => new class extends Directive {
                 public function name(): string
                 {
                     return Directive::IDLE_DETECTION;
@@ -734,7 +734,7 @@ final class DefaultFeatureGroup implements FeatureGroupContract
                     return 'https://chromestatus.com/feature/4590256452009984';
                 }
             },
-            Directive::KEYBOARD_MAP => new class extends Directive implements DirectiveContract {
+            Directive::KEYBOARD_MAP => new class extends Directive {
                 public function name(): string
                 {
                     return Directive::KEYBOARD_MAP;
@@ -760,7 +760,7 @@ final class DefaultFeatureGroup implements FeatureGroupContract
                     return 'https://www.chromestatus.com/feature/5657965899022336';
                 }
             },
-            Directive::MAGNETOMETER => new class extends Directive implements DirectiveContract {
+            Directive::MAGNETOMETER => new class extends Directive {
                 public function name(): string
                 {
                     return Directive::MAGNETOMETER;
@@ -786,7 +786,7 @@ final class DefaultFeatureGroup implements FeatureGroupContract
                     return 'https://www.chromestatus.com/feature/5758486868656128';
                 }
             },
-            Directive::MICROPHONE => new class extends Directive implements DirectiveContract {
+            Directive::MICROPHONE => new class extends Directive {
                 public function name(): string
                 {
                     return Directive::MICROPHONE;
@@ -812,7 +812,7 @@ final class DefaultFeatureGroup implements FeatureGroupContract
                     return 'https://www.chromestatus.com/feature/5023919287304192';
                 }
             },
-            Directive::MIDI => new class extends Directive implements DirectiveContract {
+            Directive::MIDI => new class extends Directive {
                 public function name(): string
                 {
                     return Directive::MIDI;
@@ -838,7 +838,7 @@ final class DefaultFeatureGroup implements FeatureGroupContract
                     return 'https://www.chromestatus.com/feature/5023919287304192';
                 }
             },
-            Directive::NAVIGATION_OVERRIDE => new class extends Directive implements DirectiveContract {
+            Directive::NAVIGATION_OVERRIDE => new class extends Directive {
                 public function name(): string
                 {
                     return Directive::NAVIGATION_OVERRIDE;
@@ -864,7 +864,7 @@ final class DefaultFeatureGroup implements FeatureGroupContract
                     return '';
                 }
             },
-            Directive::PAYMENT => new class extends Directive implements DirectiveContract {
+            Directive::PAYMENT => new class extends Directive {
                 public function name(): string
                 {
                     return Directive::PAYMENT;
@@ -890,7 +890,7 @@ final class DefaultFeatureGroup implements FeatureGroupContract
                     return '';
                 }
             },
-            Directive::PICTURE_IN_PICTURE => new class extends Directive implements DirectiveContract {
+            Directive::PICTURE_IN_PICTURE => new class extends Directive {
                 public function name(): string
                 {
                     return Directive::PICTURE_IN_PICTURE;
@@ -921,7 +921,7 @@ final class DefaultFeatureGroup implements FeatureGroupContract
                     return 'Shipped in Chrome';
                 }
             },
-            Directive::PUBLICKEY_CREDENTIALS_GET => new class extends Directive implements DirectiveContract {
+            Directive::PUBLICKEY_CREDENTIALS_GET => new class extends Directive {
                 public function name(): string
                 {
                     return Directive::PUBLICKEY_CREDENTIALS_GET;
@@ -947,7 +947,7 @@ final class DefaultFeatureGroup implements FeatureGroupContract
                     return 'https://bugs.chromium.org/p/chromium/issues/detail?id=993007';
                 }
             },
-            Directive::SCREEN_WAKE_LOCK => new class extends Directive implements DirectiveContract {
+            Directive::SCREEN_WAKE_LOCK => new class extends Directive {
                 public function name(): string
                 {
                     return Directive::SCREEN_WAKE_LOCK;
@@ -973,7 +973,7 @@ final class DefaultFeatureGroup implements FeatureGroupContract
                     return 'https://www.chromestatus.com/feature/4636879949398016';
                 }
             },
-            Directive::SERIAL => new class extends Directive implements DirectiveContract {
+            Directive::SERIAL => new class extends Directive {
                 public function name(): string
                 {
                     return Directive::SERIAL;
@@ -999,7 +999,7 @@ final class DefaultFeatureGroup implements FeatureGroupContract
                     return '';
                 }
             },
-            Directive::SPEAKER => new class extends Directive implements DirectiveContract {
+            Directive::SPEAKER => new class extends Directive {
                 public function name(): string
                 {
                     return Directive::SPEAKER;
@@ -1035,7 +1035,7 @@ final class DefaultFeatureGroup implements FeatureGroupContract
                     return true;
                 }
             },
-            Directive::SYNC_XHR => new class extends Directive implements DirectiveContract {
+            Directive::SYNC_XHR => new class extends Directive {
                 public function name(): string
                 {
                     return Directive::SYNC_XHR;
@@ -1061,7 +1061,7 @@ final class DefaultFeatureGroup implements FeatureGroupContract
                     return 'https://www.chromestatus.com/feature/5154875084111872';
                 }
             },
-            Directive::USB => new class extends Directive implements DirectiveContract {
+            Directive::USB => new class extends Directive {
                 public function name(): string
                 {
                     return Directive::USB;
@@ -1087,7 +1087,7 @@ final class DefaultFeatureGroup implements FeatureGroupContract
                     return '';
                 }
             },
-            Directive::WAKE_LOCK => new class extends Directive implements DirectiveContract {
+            Directive::WAKE_LOCK => new class extends Directive {
                 public function name(): string
                 {
                     return Directive::WAKE_LOCK;
@@ -1123,7 +1123,7 @@ final class DefaultFeatureGroup implements FeatureGroupContract
                     return true;
                 }
             },
-            Directive::WEB_SHARE => new class extends Directive implements DirectiveContract {
+            Directive::WEB_SHARE => new class extends Directive {
                 public function name(): string
                 {
                     return Directive::WEB_SHARE;
@@ -1149,7 +1149,7 @@ final class DefaultFeatureGroup implements FeatureGroupContract
                     return '';
                 }
             },
-            Directive::XR_SPATIAL_TRACKING, Directive::XR, Directive::VR => new class extends Directive implements DirectiveContract {
+            Directive::XR_SPATIAL_TRACKING, Directive::XR, Directive::VR => new class extends Directive {
                 public function name(): string
                 {
                     return 'vr';

--- a/src/FeatureGroups/ProposedFeatureGroup.php
+++ b/src/FeatureGroups/ProposedFeatureGroup.php
@@ -21,7 +21,7 @@ final class ProposedFeatureGroup implements FeatureGroupContract
         throw_unless(config('feature-policy.directives.proposal'), new DisabledFeatureGroupException($directive));
 
         return match ($directive) {
-            self::CLIPBOARD_READ => new class extends Directive implements DirectiveContract {
+            self::CLIPBOARD_READ => new class extends Directive {
                 public function name(): string
                 {
                     return ProposedFeatureGroup::CLIPBOARD_READ;
@@ -47,7 +47,7 @@ final class ProposedFeatureGroup implements FeatureGroupContract
                     return '';
                 }
             },
-            self::CLIPBOARD_WRITE => new class extends Directive implements DirectiveContract {
+            self::CLIPBOARD_WRITE => new class extends Directive {
                 public function name(): string
                 {
                     return ProposedFeatureGroup::CLIPBOARD_WRITE;
@@ -73,7 +73,7 @@ final class ProposedFeatureGroup implements FeatureGroupContract
                     return '';
                 }
             },
-            self::GAMEPAD => new class extends Directive implements DirectiveContract {
+            self::GAMEPAD => new class extends Directive {
                 public function name(): string
                 {
                     return ProposedFeatureGroup::GAMEPAD;
@@ -99,7 +99,7 @@ final class ProposedFeatureGroup implements FeatureGroupContract
                     return '';
                 }
             },
-            self::SHARED_AUTOFILL => new class extends Directive implements DirectiveContract {
+            self::SHARED_AUTOFILL => new class extends Directive {
                 public function name(): string
                 {
                     return ProposedFeatureGroup::SHARED_AUTOFILL;
@@ -125,7 +125,7 @@ final class ProposedFeatureGroup implements FeatureGroupContract
                     return '';
                 }
             },
-            self::SPEAKER_SELECTION => new class extends Directive implements DirectiveContract {
+            self::SPEAKER_SELECTION => new class extends Directive {
                 public function name(): string
                 {
                     return ProposedFeatureGroup::SPEAKER_SELECTION;

--- a/src/Formatter/FormatContract.php
+++ b/src/Formatter/FormatContract.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mazedlx\FeaturePolicy\Formatter;
+
+interface FormatContract
+{
+    public function __toString(): string;
+}

--- a/src/Formatter/PolicyFormatter.php
+++ b/src/Formatter/PolicyFormatter.php
@@ -29,10 +29,6 @@ final class PolicyFormatter implements FormatContract, Stringable
 
                 return "{$directive->name()}=({$formattedRules})";
             })
-            ->when(
-                config('feature-policy.reporting.enabled'),
-                fn (Collection $headers) => $headers->push('report-to=violation-reports')
-            )
             ->implode(',');
     }
 }

--- a/src/Formatter/PolicyFormatter.php
+++ b/src/Formatter/PolicyFormatter.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mazedlx\FeaturePolicy\Formatter;
+
+use Stringable;
+use Illuminate\Support\Collection;
+use Mazedlx\FeaturePolicy\FeatureGroups\DirectiveContract;
+
+final class PolicyFormatter implements FormatContract, Stringable
+{
+    private readonly Collection $directives;
+
+    public function __construct(array $directives)
+    {
+        $this->directives = collect($directives);
+    }
+
+    public function __toString(): string
+    {
+        return $this->directives
+            ->map(function (DirectiveContract $directive) {
+                $formattedRules = implode(' ', $directive->rules());
+
+                if (count($directive->rules()) === 1) {
+                    return "{$directive->name()}={$formattedRules}";
+                }
+
+                return "{$directive->name()}=({$formattedRules})";
+            })
+            ->when(
+                config('feature-policy.reporting.enabled'),
+                fn (Collection $headers) => $headers->push('report-to=violation-reports')
+            )
+            ->implode(',');
+    }
+}

--- a/src/Policies/Policy.php
+++ b/src/Policies/Policy.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mazedlx\FeaturePolicy\Policies;
 
 use Illuminate\Http\Request;
@@ -25,10 +27,7 @@ abstract class Policy implements PolicyContract
             ->map(fn (string $rule) => $this->isSpecialDirectiveValue($rule) ? $rule : "\"{$rule}\"")
             ->each(fn (string $rule) => $currentDirective->addRule($rule));
 
-        $this->directives[$directive] = [
-            ...$this->directives[$directive] ?? [],
-            ...$currentDirective->rules(),
-        ];
+        $this->directives[] = $currentDirective;
 
         return $this;
     }
@@ -40,7 +39,9 @@ abstract class Policy implements PolicyContract
 
     public function applyTo(Response $response): void
     {
-        $this->configure();
+        if (! $this->directives) {
+            $this->configure();
+        }
 
         $headerName = 'Permissions-Policy';
 

--- a/src/Policies/Policy.php
+++ b/src/Policies/Policy.php
@@ -21,9 +21,8 @@ abstract class Policy implements PolicyContract
 
     public function addDirective(string $directive, $values, ?string $type = DefaultFeatureGroup::class): self
     {
-        $this->rules[$directive] ??= [];
         $currentDirective = Directive::make($directive, type: $type);
-        collect($this->rules[$directive])
+        collect($this->rules[$directive] ??= [])
             ->each(fn (string $rule) => $currentDirective->addRule($rule));
 
         collect($values)

--- a/src/Policies/Policy.php
+++ b/src/Policies/Policy.php
@@ -6,10 +6,9 @@ use Illuminate\Http\Request;
 use Mazedlx\FeaturePolicy\FeatureGroups\DefaultFeatureGroup;
 use Mazedlx\FeaturePolicy\Value;
 use Mazedlx\FeaturePolicy\Directive;
-use Stringable;
 use Symfony\Component\HttpFoundation\Response;
 
-abstract class Policy implements PolicyContract, Stringable
+abstract class Policy implements PolicyContract
 {
     protected array $directives = [];
 

--- a/src/Policies/Policy.php
+++ b/src/Policies/Policy.php
@@ -4,6 +4,7 @@ namespace Mazedlx\FeaturePolicy\Policies;
 
 use Illuminate\Http\Request;
 use Mazedlx\FeaturePolicy\FeatureGroups\DefaultFeatureGroup;
+use Mazedlx\FeaturePolicy\Formatter\PolicyFormatter;
 use Mazedlx\FeaturePolicy\Value;
 use Mazedlx\FeaturePolicy\Directive;
 use Symfony\Component\HttpFoundation\Response;
@@ -52,16 +53,7 @@ abstract class Policy implements PolicyContract
 
     public function __toString(): string
     {
-        return collect($this->directives)
-            ->map(function (array $rules, string $directive) {
-                $formattedRules = implode(' ', $rules);
-
-                if (count($rules) === 1) {
-                    return "{$directive}={$formattedRules}";
-                }
-
-                return "{$directive}=({$formattedRules})";
-            })->implode(',');
+        return (string) new PolicyFormatter($this->directives);
     }
 
     protected function isSpecialDirectiveValue(string $value): bool

--- a/src/Policies/PolicyContract.php
+++ b/src/Policies/PolicyContract.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 namespace Mazedlx\FeaturePolicy\Policies;
 
+use Stringable;
 use Illuminate\Http\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-interface PolicyContract
+interface PolicyContract extends Stringable
 {
     public function addDirective(string $directive, $values, ?string $type = 'default'): self;
     public function shouldBeApplied(Request $request, Response $response): bool;

--- a/tests/FeatureGroupTest.php
+++ b/tests/FeatureGroupTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mazedlx\FeaturePolicy\Tests;
+
+use Mazedlx\FeaturePolicy\Exceptions\DisabledFeatureGroupException;
+use Mazedlx\FeaturePolicy\FeatureGroups\ProposedFeatureGroup;
+use Mazedlx\FeaturePolicy\Policies\Policy;
+use Mazedlx\FeaturePolicy\Value;
+use PHPUnit\Framework\Attributes\Test;
+
+final class FeatureGroupTest extends TestCase
+{
+    #[Test]
+    public function it_will_throw_an_exception_for_a_disabled_feature_group(): void
+    {
+        $this->withoutExceptionHandling();
+
+        $this->expectException(DisabledFeatureGroupException::class);
+        $this->expectExceptionMessage('The directive (gamepad) is disabled.');
+
+        $policy = new class extends Policy {
+            public function configure(): void
+            {
+                $this->addDirective(ProposedFeatureGroup::GAMEPAD, [Value::ALL], ProposedFeatureGroup::class);
+            }
+        };
+
+        config()->set('feature-policy.policy', $policy::class);
+
+        $this->get('test-route')
+            ->assertHeaderMissing('Permissions-Policy');
+    }
+
+    #[Test]
+    public function it_will_render_an_enabled_feature_group(): void
+    {
+        $policy = new class extends Policy {
+            public function configure(): void
+            {
+                $this->addDirective(ProposedFeatureGroup::CLIPBOARD_READ, [Value::ALL], ProposedFeatureGroup::class);
+            }
+        };
+
+        config()->set('feature-policy.policy', $policy::class);
+        config()->set('feature-policy.directives.proposal', true);
+
+        $this->get('test-route')
+            ->assertHeader('Permissions-Policy');
+    }
+}


### PR DESCRIPTION
While working on something different I found a better way to hold the directives/rules.
However it resulted, or maybe it was already broken I don't know, that the rules weren't generated correctly.

## What does this pull request change or introduce
- store the added directives as an object
- store the rules in a separate array
- extract the `__toString()` to a separate class (prepare for different output in the future)

## What is the impact of these changes
Generating the rules for the added directives.

## Checklist
- [ ] An issue was created before proposing this change
- [x] Tests for the changes have been added
- [x] Tests are passing

## Steps to reproduce / test
Run the tests, new tests were added to check for this bug.
