### PR TITLE
add reporting API for permission policy

### DIFF
--- a/config/feature-policy.php
+++ b/config/feature-policy.php
@@ -1,7 +1,6 @@
 <?php
 
 return [
-    // Feature-policy headers will only be added if this is set to true
     'enabled' => env('FPH_ENABLED', true),
 
     /*
@@ -10,8 +9,15 @@ return [
      */
     'policy' => Mazedlx\FeaturePolicy\Policies\Basic::class,
 
+    /** @see https://github.com/w3c/webappsec-permissions-policy/blob/main/features.md */
     'directives' => [
         'proposal' => env('FPH_PROPOSAL_ENABLED', false),
         'experimental' => env('FPH_EXPERIMENTAL_ENABLED', false),
+    ],
+
+    'reporting' => [
+        'enabled' => env('FPH_REPORTING_ENABLED', false),
+        'report_only' => env('FPH_REPORT_ONLY', false),
+        'url' => env('FPH_REPORTING_URL', 'https://reportingapi.tools/public/submit'),
     ],
 ];

--- a/src/Formatter/FormatContract.php
+++ b/src/Formatter/FormatContract.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Mazedlx\FeaturePolicy\Formatter;
 
-interface FormatContract
+use Stringable;
+
+interface FormatContract extends Stringable
 {
     public function __toString(): string;
 }

--- a/src/Formatter/PolicyFormatter.php
+++ b/src/Formatter/PolicyFormatter.php
@@ -8,7 +8,7 @@ use Stringable;
 use Illuminate\Support\Collection;
 use Mazedlx\FeaturePolicy\FeatureGroups\DirectiveContract;
 
-final class PolicyFormatter implements FormatContract, Stringable
+final class PolicyFormatter implements FormatContract
 {
     private readonly Collection $directives;
 

--- a/src/Formatter/PolicyFormatter.php
+++ b/src/Formatter/PolicyFormatter.php
@@ -29,6 +29,12 @@ final class PolicyFormatter implements FormatContract
 
                 return "{$directive->name()}=({$formattedRules})";
             })
+            ->when(
+                config('feature-policy.reporting.enabled'),
+                function (Collection $collection) {
+                    $collection->add('report-to=violation-reports');
+                }
+            )
             ->implode(',');
     }
 }

--- a/src/Policies/Policy.php
+++ b/src/Policies/Policy.php
@@ -55,6 +55,24 @@ abstract class Policy implements PolicyContract
         }
 
         $response->headers->set($headerName, (string) $this);
+
+        if (! config('feature-policy.reporting.enabled')) {
+            return;
+        }
+
+        $response->headers->set('Reporting-Endpoints', 'violation-reports="' . config('feature-policy.reporting.url') . '"');
+
+        if (! config('feature-policy.reporting.report_only')) {
+            return;
+        }
+
+        $headerName = 'Permissions-Policy-Report-Only';
+
+        if ($response->headers->has($headerName)) {
+            return;
+        }
+
+        $response->headers->set($headerName, (string) $this);
     }
 
     public function __toString(): string

--- a/tests/AddFeaturePolicyHeadersTest.php
+++ b/tests/AddFeaturePolicyHeadersTest.php
@@ -163,4 +163,49 @@ final class AddFeaturePolicyHeadersTest extends TestCase
         $this->get('other-route')
             ->assertHeader('Permissions-Policy', 'fullscreen="custom-policy"');
     }
+
+    #[Test]
+    public function it_can_enable_reporting_of_permission_violations(): void
+    {
+        config()->set('feature-policy.reporting.enabled', true);
+
+        $policy = new class extends Policy {
+            public function configure(): void
+            {
+                $this->addDirective(Directive::CAMERA, [Value::ALL]);
+            }
+        };
+
+        config()->set('feature-policy.policy', $policy::class);
+
+        $response = $this->get('test-route')->assertSuccessful();
+
+        $response->assertHeader('Reporting-Endpoints', 'violation-reports="' . config('feature-policy.reporting.url') . '"');
+        $response->assertHeader('Permissions-Policy', 'camera=*,report-to=violation-reports');
+
+        $response->assertHeaderMissing('Permissions-Policy-Report-Only');
+    }
+
+    #[Test]
+    public function it_can_enable_report_only_permission_violations(): void
+    {
+        config()->set('feature-policy.reporting.enabled', true);
+        config()->set('feature-policy.reporting.report_only', true);
+
+        $policy = new class extends Policy {
+            public function configure(): void
+            {
+                $this->addDirective(Directive::CAMERA, [Value::ALL]);
+            }
+        };
+
+        config()->set('feature-policy.policy', $policy::class);
+
+        $response = $this->get('test-route')->assertSuccessful();
+
+        $response->assertHeader('Reporting-Endpoints', 'violation-reports="' . config('feature-policy.reporting.url') . '"');
+        $response->assertHeader('Permissions-Policy', 'camera=*,report-to=violation-reports');
+        $response->assertHeader('Permissions-Policy-Report-Only', 'camera=*,report-to=violation-reports');
+
+    }
 }

--- a/tests/AddFeaturePolicyHeadersTest.php
+++ b/tests/AddFeaturePolicyHeadersTest.php
@@ -14,12 +14,10 @@ final class AddFeaturePolicyHeadersTest extends TestCase
     #[Test]
     public function it_sets_the_default_feature_policy_headers(): void
     {
-        $permissionPolicyHeader = $this->get('test-route')
-            ->assertSuccessful()
-            ->headers
-            ->get('Permissions-Policy');
+        $response = $this->get('test-route')
+            ->assertSuccessful();
 
-        $this->assertStringContainsString('geolocation=self', $permissionPolicyHeader);
+        $response->assertHeader('Permissions-Policy', 'geolocation=self,fullscreen=self');
     }
 
     #[Test]
@@ -153,7 +151,7 @@ final class AddFeaturePolicyHeadersTest extends TestCase
         $this->withoutExceptionHandling();
 
         $customPolicy = new class extends Policy {
-            public function configure()
+            public function configure(): void
             {
                 $this->addDirective(Directive::FULLSCREEN, 'custom-policy');
             }


### PR DESCRIPTION
## What does this pull request change or introduce
It adds reporting functionality for the permissions policy as seen in [W3C docs](https://github.com/w3c/webappsec-permissions-policy/blob/main/reporting.md)

## What is the impact of these changes
Formatting the directives and setting the headers itself

## Checklist
- [x] An issue was created before proposing this change
- [x] Tests for the changes have been added
- [x] Tests are passing

## Steps to reproduce / test
This is covered by the added tests, but it comes down to this.

1. visit a page, it should not have reporting related headers
2. enable reporting, it should have two reporting headers
3. also enable the report only config, it should have three reporting headers

Reporting headers;
1. Reporting-Endpoints
2. Permissions-Policy-Report-Only
3. Permissions-Policy

The two latter have an additional directive called: `report-to=violation-reports`
## Other information:
resolves #32 