### PR TITLE
fix adding middleware to test route

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -13,9 +13,7 @@ use Rector\Php80\Rector\Switch_\ChangeSwitchToMatchRector;
 use Rector\Php81\Rector\Property\ReadOnlyPropertyRector;
 use Rector\Privatization\Rector\Class_\FinalizeClassesWithoutChildrenRector;
 use Rector\Set\ValueObject\LevelSetList;
-use Rector\TypeDeclaration\Rector\ClassMethod\AddParamTypeDeclarationRector;
 use Rector\TypeDeclaration\Rector\Property\TypedPropertyFromStrictSetUpRector;
-use RectorLaravel\Set\LaravelLevelSetList;
 
 /**
  * @see https://github.com/rectorphp/rector/blob/main/docs/rector_rules_overview.md
@@ -36,7 +34,6 @@ return static function (RectorConfig $rectorConfig): void {
         ChangeAndIfToEarlyReturnRector::class,
         RemoveUnusedVariableInCatchRector::class,
         FinalizeClassesWithoutChildrenRector::class,
-        AddParamTypeDeclarationRector::class,
         TypedPropertyFromStrictSetUpRector::class,
         ReadOnlyPropertyRector::class,
         ChangeSwitchToMatchRector::class,
@@ -46,7 +43,7 @@ return static function (RectorConfig $rectorConfig): void {
     // define sets of rules
     $rectorConfig->sets([
         LevelSetList::UP_TO_PHP_81,
-        // LaravelLevelSetList::UP_TO_LARAVEL_100,
+        // \RectorLaravel\Set\LaravelLevelSetList::UP_TO_LARAVEL_100,
     ]);
 
     $rectorConfig->skip([

--- a/rector.php
+++ b/rector.php
@@ -5,13 +5,12 @@ declare(strict_types=1);
 use Rector\Caching\ValueObject\Storage\FileCacheStorage;
 use Rector\CodeQuality\Rector\Class_\InlineConstructorDefaultToPropertyRector;
 use Rector\Config\RectorConfig;
-use Rector\EarlyReturn\Rector\If_\ChangeAndIfToEarlyReturnRector;
+use Rector\EarlyReturn\Rector\If_\ChangeIfElseValueAssignToEarlyReturnRector;
 use Rector\Php74\Rector\Closure\ClosureToArrowFunctionRector;
 use Rector\Php80\Rector\Catch_\RemoveUnusedVariableInCatchRector;
 use Rector\Php80\Rector\ClassMethod\FinalPrivateToPrivateVisibilityRector;
 use Rector\Php80\Rector\Switch_\ChangeSwitchToMatchRector;
 use Rector\Php81\Rector\Property\ReadOnlyPropertyRector;
-use Rector\Privatization\Rector\Class_\FinalizeClassesWithoutChildrenRector;
 use Rector\Set\ValueObject\LevelSetList;
 use Rector\TypeDeclaration\Rector\Property\TypedPropertyFromStrictSetUpRector;
 
@@ -31,9 +30,8 @@ return static function (RectorConfig $rectorConfig): void {
     // register a single rule
     $rectorConfig->rules([
         InlineConstructorDefaultToPropertyRector::class,
-        ChangeAndIfToEarlyReturnRector::class,
+        ChangeIfElseValueAssignToEarlyReturnRector::class,
         RemoveUnusedVariableInCatchRector::class,
-        FinalizeClassesWithoutChildrenRector::class,
         TypedPropertyFromStrictSetUpRector::class,
         ReadOnlyPropertyRector::class,
         ChangeSwitchToMatchRector::class,

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -19,7 +19,7 @@ abstract class TestCase extends Orchestra
         Route::get('test-route', static fn () => 'ok');
     }
 
-    protected function getPackageProviders($app)
+    protected function getPackageProviders($app): array
     {
         return [
             FeaturePolicyServiceProvider::class,

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,7 +2,6 @@
 
 namespace Mazedlx\FeaturePolicy\Tests;
 
-use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Support\Facades\Route;
 use Mazedlx\FeaturePolicy\AddFeaturePolicyHeaders;
 use Orchestra\Testbench\TestCase as Orchestra;
@@ -14,9 +13,8 @@ abstract class TestCase extends Orchestra
     {
         parent::setUp();
 
-        app(Kernel::class)->pushMiddleware(AddFeaturePolicyHeaders::class);
-
-        Route::get('test-route', static fn () => 'ok');
+        Route::middleware(AddFeaturePolicyHeaders::class)
+            ->get('test-route', static fn () => 'ok');
     }
 
     protected function getPackageProviders($app): array


### PR DESCRIPTION
resolves #60

## What does this pull request change or introduce

Updates the way the middleware is added to routes. It was using an outdated method on the `Kernel` class.
Switched to declaring it on the route itself, which (I think) is common practise.

Also updated the Rector config, as it was not updated after the upgrade to v1

## What is the impact of these changes

Mostly tests & static analysis

## Checklist
- [x] An issue was created before proposing this change
- [ ] Tests for the changes have been added
- [ ] Tests are passing

## Steps to reproduce / test
1. run tests (`vendor/bin/phpunit`)
2. run PHPStan (`vendor/bin/phpstan analyse --no-ansi --verbose`)
3. run Rector (`vendor/bin/rector process --no-ansi`)
