### PR TITLE
Fix report-to directive

### DIFF
--- a/src/Formatter/PolicyFormatter.php
+++ b/src/Formatter/PolicyFormatter.php
@@ -19,7 +19,7 @@ final class PolicyFormatter implements FormatContract
 
     public function __toString(): string
     {
-        return $this->directives
+        $policy = $this->directives
             ->map(function (DirectiveContract $directive) {
                 $formattedRules = implode(' ', $directive->rules());
 
@@ -29,12 +29,13 @@ final class PolicyFormatter implements FormatContract
 
                 return "{$directive->name()}=({$formattedRules})";
             })
-            ->when(
-                config('feature-policy.reporting.enabled'),
-                function (Collection $collection) {
-                    $collection->add('report-to=violation-reports');
-                }
-            )
             ->implode(',');
+
+        if (config('feature-policy.reporting.enabled')) {
+            $policy .= '; report-to=violation-reports';
+        }
+
+        return $policy;
     }
+
 }

--- a/tests/AddFeaturePolicyHeadersTest.php
+++ b/tests/AddFeaturePolicyHeadersTest.php
@@ -181,7 +181,7 @@ final class AddFeaturePolicyHeadersTest extends TestCase
         $response = $this->get('test-route')->assertSuccessful();
 
         $response->assertHeader('Reporting-Endpoints', 'violation-reports="' . config('feature-policy.reporting.url') . '"');
-        $response->assertHeader('Permissions-Policy', 'camera=*,report-to=violation-reports');
+        $response->assertHeader('Permissions-Policy', 'camera=*; report-to=violation-reports');
 
         $response->assertHeaderMissing('Permissions-Policy-Report-Only');
     }
@@ -204,8 +204,8 @@ final class AddFeaturePolicyHeadersTest extends TestCase
         $response = $this->get('test-route')->assertSuccessful();
 
         $response->assertHeader('Reporting-Endpoints', 'violation-reports="' . config('feature-policy.reporting.url') . '"');
-        $response->assertHeader('Permissions-Policy', 'camera=*,report-to=violation-reports');
-        $response->assertHeader('Permissions-Policy-Report-Only', 'camera=*,report-to=violation-reports');
+        $response->assertHeader('Permissions-Policy', 'camera=*; report-to=violation-reports');
+        $response->assertHeader('Permissions-Policy-Report-Only', 'camera=*; report-to=violation-reports');
 
     }
 }


### PR DESCRIPTION
## What does this pull request change or introduce
This pull request fixes the formatting of the report-to directive in the generated Permissions-Policy / Feature-Policy header.

Previously, when reporting was enabled, the report-to=violation-reports directive was appended using a comma (,), making it part of the directive list. According to the specification, report-to must be appended as a separate parameter, prefixed by a semicolon (;).

## What is the impact of these changes
Fixes invalid header formatting when reporting is enabled
